### PR TITLE
Add CLI tool for vibe transmutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ const shrine = VibeCoder.transmute({
 console.log(shrine.manifest());
 ```
 
+## ⚙️ CLI Invocation
+
+If you prefer command line ceremonies, run `node cli.js` with either a JSON file
+or individual options:
+
+```bash
+# From a JSON specification
+node cli.js params.json
+
+# Or with direct flags
+node cli.js --vibe cosmic_dream --emotion nostalgic_wonder --symbols spiral,lotus --ritual_type landing_page
+```
+
+The CLI outputs a JSON object containing the generated `html`, `css`, and `js`
+segments ready for your shrine.
+
 ## 🛡️ Intellectual Property Protection
 
 This work is protected across multiple dimensions:

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+<!-- 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ -->
+
+const fs = require('fs');
+
+(async () => {
+  const { VibeCoder } = await import('./src/vibeCore.js');
+
+  const args = process.argv.slice(2);
+  let params = {};
+
+  if (args.length === 1 && args[0].endsWith('.json')) {
+    const content = fs.readFileSync(args[0], 'utf8');
+    params = JSON.parse(content);
+  } else if (args.length === 1 && args[0].trim().startsWith('{')) {
+    params = JSON.parse(args[0]);
+  } else {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (arg.startsWith('--')) {
+        const key = arg.replace(/^--/, '');
+        let val = args[i + 1];
+        if (val && !val.startsWith('--')) {
+          i++;
+        } else {
+          val = true;
+        }
+        if (key === 'symbols' && typeof val === 'string') {
+          params.symbols = val.split(',').map(s => s.trim());
+        } else {
+          params[key] = val;
+        }
+      }
+    }
+  }
+
+  if (!params.vibe) {
+    console.error('Usage: node cli.js --vibe <signature> [--emotion <feeling>] [--symbols a,b,c] [--ritual_type <type>]');
+    console.error('   or: node cli.js path/to/params.json');
+    process.exit(1);
+  }
+
+  const coder = new VibeCoder();
+  const ceremony = coder.transmute(params);
+  const artifacts = ceremony.exportRitual('complete');
+  console.log(JSON.stringify(artifacts, null, 2));
+})();


### PR DESCRIPTION
## Summary
- add `cli.js` Node script to generate artifacts from command line parameters or JSON file
- document CLI workflow in the README

## Testing
- `node cli.js --vibe test --emotion nostalgic_wonder --symbols spiral,lotus --ritual_type landing_page | head`

------
https://chatgpt.com/codex/tasks/task_e_687ca56bf2e88322974de1da66edef3e