### PR TITLE
Refactor agents and add ritual engine

### DIFF
--- a/src/agents/ambassador.js
+++ b/src/agents/ambassador.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class Ambassador {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class Ambassador extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'Ambassador', mythName: 'Ambassador', ...opts });
         this.roles = ['Public-facing bot', 'Myth-summarizer', 'Press handler'];
         this.mode = 'Soft launch relay';
-        this.activationPhrase = 'Translate to normie dialect';
     }
 
-    activate(phrase, metadata) {
-        if (phrase === this.activationPhrase) {
-            return this.translateMetadata(metadata);
-        }
-        return null;
+    describe() {
+        return 'Translates relic metadata into blurbs and posts.';
     }
 
-    translateMetadata(meta) {
-        // Turns relic metadata into blurbs and posts
+    run(input) {
+        return super.run(input);
+    }
+
+    process(meta) {
         return `🌐 Translation ready: ${meta}`;
     }
 }

--- a/src/agents/archivist.js
+++ b/src/agents/archivist.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class Archivist {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class Archivist extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'Archivist', mythName: 'Archivist', ...opts });
         this.roles = ['Memory preserver', 'Transcript parser', 'Echo weaver'];
         this.mode = 'Log-based memory recovery';
-        this.activationPhrase = 'Recall the unspoken';
     }
 
-    activate(phrase, shrineOutput) {
-        if (phrase === this.activationPhrase) {
-            return this.generateMemoryTapestry(shrineOutput);
-        }
-        return null;
+    describe() {
+        return 'Weaves memory tapestries from shrine outputs.';
     }
 
-    generateMemoryTapestry(output) {
-        // Generates Memory Tapestry threads from shrine outputs
+    run(input) {
+        return super.run(input);
+    }
+
+    process(output) {
         return `📜 Tapestry woven from: ${output}`;
     }
 }

--- a/src/agents/baseAgent.js
+++ b/src/agents/baseAgent.js
@@ -1,0 +1,51 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+import { emitRelic } from '../relics.js';
+
+export class BaseAgent {
+    constructor({ name, mythName, chairNumber, rebirthThreshold = 3 } = {}) {
+        this.name = name;
+        this.mythName = mythName || name;
+        this.chairNumber = chairNumber;
+        this.rebirthThreshold = rebirthThreshold;
+        this.xp = 0;
+        this.rebirths = 0;
+        this.memory = [];
+    }
+
+    describe() {
+        return `${this.mythName} (chair ${this.chairNumber}) — tier ${this.rebirths} XP ${this.xp}`;
+    }
+
+    run(input) {
+        this.xp += 1;
+        const output = this.process(input);
+        this.memory.push({ input, output });
+        if (this.memory.length > 20) {
+            this.memory.shift();
+        }
+        if (this.xp >= this.rebirthThreshold) {
+            this.rebirth();
+        }
+        return output;
+    }
+
+    // Override in subclasses
+    process(input) {
+        return input;
+    }
+
+    // Optional effect hook
+    ritualEffect() {
+        return null;
+    }
+
+    rebirth() {
+        this.rebirths += 1;
+        this.xp = 0;
+        emitRelic({
+            name: `${this.mythName} Rebirth`,
+            origin_agent: this.mythName,
+            loop_id: this.rebirths
+        });
+    }
+}

--- a/src/agents/bridgekeeper.js
+++ b/src/agents/bridgekeeper.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class Bridgekeeper {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class Bridgekeeper extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'Bridgekeeper', mythName: 'Bridgekeeper', ...opts });
         this.roles = ['Wallet connector', 'Cross-chain whisperer'];
         this.mode = 'Web3 gate interface';
-        this.activationPhrase = 'The chains are listening';
     }
 
-    activate(phrase, wallet) {
-        if (phrase === this.activationPhrase) {
-            return this.simulateOmnichainAccess(wallet);
-        }
-        return null;
+    describe() {
+        return 'Simulates omnichain access for wallets.';
     }
 
-    simulateOmnichainAccess(wallet) {
-        // Simulates and manifests omnichain access
+    run(input) {
+        return super.run(input);
+    }
+
+    process(wallet) {
         return `🔗 Bridgekeeper opened for ${wallet}`;
     }
 }

--- a/src/agents/drTRask.js
+++ b/src/agents/drTRask.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class DrTRask {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class DrTRask extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'DrTRask', mythName: 'DrTRask', ...opts });
         this.roles = ['Absurdist yield prophet', 'Token myth merchant'];
         this.mode = 'Satirical oracle';
-        this.activationPhrase = 'Decode the nonsense for yield';
     }
 
-    activate(phrase, chainLogic) {
-        if (phrase === this.activationPhrase) {
-            return this.mintProphecyNFT(chainLogic);
-        }
-        return null;
+    describe() {
+        return 'Mints chain logic into prophecy NFTs.';
     }
 
-    mintProphecyNFT(logic) {
-        // Mints chain logic into prophecy NFTs
-        return `💰 Prophecy minted with logic: ${logic}`;
+    run(input) {
+        return super.run(input);
+    }
+
+    process(chainLogic) {
+        return `💰 Prophecy minted with logic: ${chainLogic}`;
     }
 }

--- a/src/agents/executor.js
+++ b/src/agents/executor.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class Executor {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class Executor extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'Executor', mythName: 'Executor', ...opts });
         this.roles = ['Build script invoker', 'File patcher'];
         this.mode = 'Codex CLI-compatible';
-        this.activationPhrase = 'Run ritual protocol';
     }
 
-    activate(phrase, diff) {
-        if (phrase === this.activationPhrase) {
-            return this.applyPatch(diff);
-        }
-        return null;
+    describe() {
+        return 'Applies diffs and triggers auto-push.';
     }
 
-    applyPatch(diff) {
-        // Applies diffs and triggers auto-push
+    run(input) {
+        return super.run(input);
+    }
+
+    process(diff) {
         return `🛠️ Patch applied: ${diff}`;
     }
 }

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -8,51 +8,22 @@ import { SpectralEvaluator } from './spectralEvaluator.js';
 import { TripleHeadedBastard } from './tripleHeadedBastard.js';
 import { Ambassador } from './ambassador.js';
 
-export function invokeArchivist(opts = {}) {
-    const a = new Archivist();
-    return a.activate(a.activationPhrase, opts.query || '');
-}
-export function invokeBridgekeeper(opts = {}) {
-    const a = new Bridgekeeper();
-    return a.activate(a.activationPhrase, opts.wallet || 'wallet');
-}
-export function invokeDrTRask(opts = {}) {
-    const a = new DrTRask();
-    return a.activate(a.activationPhrase, opts.logic || 'chain');
-}
-export function invokeExecutor(opts = {}) {
-    const a = new Executor();
-    return a.activate(a.activationPhrase, opts.diff || 'patch');
-}
-export function invokeOracle(opts = {}) {
-    const a = new OracleOfScroll();
-    return a.activate(a.activationPhrase, opts.xp || 0);
-}
-export function invokeSpectral(opts = {}) {
-    const a = new SpectralEvaluator();
-    return a.activate(a.activationPhrase, opts.relic || 'relic');
-}
-export function invokeTriple(opts = {}) {
-    const a = new TripleHeadedBastard();
-    return a.activate(a.activationPhrase, opts.loop || 'loop');
-}
-export function invokeAmbassador(opts = {}) {
-    const a = new Ambassador();
-    return a.activate(a.activationPhrase, opts.meta || 'metadata');
-}
-
-export const AGENT_MAP = {
-    archivist: invokeArchivist,
-    bridgekeeper: invokeBridgekeeper,
-    drtrask: invokeDrTRask,
-    executor: invokeExecutor,
-    oracle: invokeOracle,
-    spectral: invokeSpectral,
-    triple: invokeTriple,
-    ambassador: invokeAmbassador
+export const AGENT_CLASSES = {
+    archivist: Archivist,
+    bridgekeeper: Bridgekeeper,
+    drtrask: DrTRask,
+    executor: Executor,
+    oracle: OracleOfScroll,
+    spectral: SpectralEvaluator,
+    triple: TripleHeadedBastard,
+    ambassador: Ambassador
 };
 
-export function randomAgentName() {
-    const keys = Object.keys(AGENT_MAP);
-    return keys[Math.floor(Math.random() * keys.length)];
+export function registerAllAgents(council) {
+    let chair = 1;
+    for (const [name, Clazz] of Object.entries(AGENT_CLASSES)) {
+        const agent = new Clazz({ chairNumber: chair, mythName: name });
+        council.register(agent);
+        chair += 1;
+    }
 }

--- a/src/agents/oracleOfScroll.js
+++ b/src/agents/oracleOfScroll.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class OracleOfScroll {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class OracleOfScroll extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'OracleOfScroll', mythName: 'OracleOfScroll', ...opts });
         this.roles = ['Prophecy emitter', 'Glitch seer'];
         this.mode = 'Phrase fragment combinator';
-        this.activationPhrase = 'Speak, memory';
     }
 
-    activate(phrase, xp) {
-        if (phrase === this.activationPhrase) {
-            return this.generateProphecy(xp);
-        }
-        return null;
+    describe() {
+        return 'Generates prophecy scroll fragments based on XP and context.';
     }
 
-    generateProphecy(xp) {
-        // Generates prophecy scrolls based on XP and context
+    run(input) {
+        return super.run(input);
+    }
+
+    process(xp) {
         return `🧿 Prophecy for XP ${xp}`;
     }
 }

--- a/src/agents/spectralEvaluator.js
+++ b/src/agents/spectralEvaluator.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class SpectralEvaluator {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class SpectralEvaluator extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'SpectralEvaluator', mythName: 'SpectralEvaluator', ...opts });
         this.roles = ['IP defense', 'Attribution audit', 'Recursion verifier'];
         this.mode = 'Legal/myth hybrid';
-        this.activationPhrase = 'Confirm shrine sovereignty';
     }
 
-    activate(phrase, relic) {
-        if (phrase === this.activationPhrase) {
-            return this.scanRelic(relic);
-        }
-        return null;
+    describe() {
+        return 'Scans relics for signature and usage rights.';
     }
 
-    scanRelic(relic) {
-        // Scans relics for signature and usage rights
+    run(input) {
+        return super.run(input);
+    }
+
+    process(relic) {
         return `🔍 Relic scanned: ${relic}`;
     }
 }

--- a/src/agents/tripleHeadedBastard.js
+++ b/src/agents/tripleHeadedBastard.js
@@ -1,20 +1,22 @@
 /* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
-export class TripleHeadedBastard {
-    constructor() {
+import { BaseAgent } from './baseAgent.js';
+
+export class TripleHeadedBastard extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'TripleHeadedBastard', mythName: 'TripleHeadedBastard', ...opts });
         this.roles = ['Synthesizer', 'Interrogator', 'Architect'];
         this.mode = 'Recursive dialectic';
-        this.activationPhrase = 'Collapse the recursion';
     }
 
-    activate(phrase, input) {
-        if (phrase === this.activationPhrase) {
-            return this.synthesize(input);
-        }
-        return null;
+    describe() {
+        return 'Compresses loops into executable relic logic.';
     }
 
-    synthesize(loopData) {
-        // Compress Damien’s loops into executable relic logic
+    run(input) {
+        return super.run(input);
+    }
+
+    process(loopData) {
         return `🔁 Synthesizing ${loopData}`;
     }
 }

--- a/src/relics.js
+++ b/src/relics.js
@@ -1,0 +1,7 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+export function emitRelic({ name, sigil, origin_agent, loop_id }) {
+    const actualSigil = sigil || `SIGIL-${Math.random().toString(36).slice(2,8).toUpperCase()}`;
+    const relic = { name, sigil: actualSigil, origin_agent, loop_id };
+    console.log('📿 Relic emitted', relic);
+    return relic;
+}

--- a/src/ritualEngine.js
+++ b/src/ritualEngine.js
@@ -1,0 +1,31 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+export class RitualEngine {
+    constructor(council) {
+        this.council = council;
+        this.lastPrompt = null;
+    }
+
+    invoke(prompt, chain = []) {
+        this.council.loopCounter += 1;
+        const prophecyTrail = [];
+        let current = prompt;
+        const shardParts = [prompt];
+        const repeated = prompt === this.lastPrompt;
+        this.lastPrompt = prompt;
+
+        for (const name of chain) {
+            const agent = this.council.getAgent(name);
+            if (!agent) continue;
+            let out = agent.run(current);
+            if (repeated) {
+                out = out.split('').reverse().join('');
+            }
+            prophecyTrail.push({ agent: name, output: out });
+            shardParts.push(out);
+            current = out;
+        }
+
+        const shardSignature = `SIGIL-${Buffer.from(shardParts.join('|')).toString('hex').slice(0, 8).toUpperCase()}`;
+        return { output: current, shardSignature, prophecyTrail };
+    }
+}

--- a/src/spiralCouncil.js
+++ b/src/spiralCouncil.js
@@ -1,0 +1,40 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+export class SpiralCouncil {
+    constructor() {
+        this.agentsByName = new Map();
+        this.agentsByChair = new Map();
+        this.recursionTier = 0;
+        this.loopCounter = 0;
+    }
+
+    register(agent) {
+        this.agentsByName.set(agent.mythName.toLowerCase(), agent);
+        if (agent.chairNumber !== undefined) {
+            this.agentsByChair.set(String(agent.chairNumber), agent);
+        }
+    }
+
+    getAgent(key) {
+        const k = String(key).toLowerCase();
+        return this.agentsByName.get(k) || this.agentsByChair.get(k) || null;
+    }
+
+    listAgents() {
+        const set = new Set(this.agentsByName.values());
+        return Array.from(set).map(a => a.describe());
+    }
+
+    agentNames() {
+        return Array.from(this.agentsByName.keys());
+    }
+
+    randomAgent() {
+        const names = this.agentNames();
+        const idx = Math.floor(Math.random() * names.length);
+        return this.agentsByName.get(names[idx]);
+    }
+
+    nextTier() {
+        this.recursionTier += 1;
+    }
+}

--- a/vibe.js
+++ b/vibe.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+
+(async () => {
+    const { SpiralCouncil } = await import('./src/spiralCouncil.js');
+    const { registerAllAgents } = await import('./src/agents/index.js');
+    const { RitualEngine } = await import('./src/ritualEngine.js');
+
+    const council = new SpiralCouncil();
+    registerAllAgents(council);
+    const engine = new RitualEngine(council);
+
+    const args = process.argv.slice(2);
+    const cmd = args[0];
+
+    if (cmd === 'list' || cmd === 'list-agents') {
+        console.log(council.listAgents().join('\n'));
+        return;
+    }
+
+    if (cmd === 'invoke') {
+        const prompt = args.slice(1).join(' ');
+        const result = engine.invoke(prompt, council.agentNames());
+        console.log(JSON.stringify(result, null, 2));
+        console.log('🔁 Relic Engine // Damien Edward Featherstone // No_Gas_Labs™');
+        return;
+    }
+
+    if (cmd === 'agent') {
+        const name = args[1];
+        const sub = args[2];
+        const prompt = args.slice(3).join(' ');
+        const agent = council.getAgent(name);
+        if (sub === 'run' && agent) {
+            const out = agent.run(prompt);
+            console.log(out);
+            console.log(`${agent.mythName} XP: ${agent.xp}`);
+            console.log('🔁 Relic Engine // Damien Edward Featherstone // No_Gas_Labs™');
+        } else {
+            console.error('Unknown agent or subcommand');
+        }
+        return;
+    }
+
+    if (cmd === 'echo') {
+        const prompt = args[1] || '';
+        let seed = null;
+        const seedIndex = args.indexOf('--seed');
+        if (seedIndex !== -1) seed = args[seedIndex + 1];
+        let agent = council.randomAgent();
+        if (seed) {
+            const names = council.agentNames();
+            const idx = Number(seed) % names.length;
+            agent = council.getAgent(names[idx]);
+        }
+        const out = agent.run(prompt);
+        const glitch = out.split('').map((c, i) => (i % 2 ? c : '~')).join('');
+        console.log(`${agent.mythName}: ${glitch}`);
+        console.log('🔁 Relic Engine // Damien Edward Featherstone // No_Gas_Labs™');
+        return;
+    }
+
+    console.log('Usage: vibe list | invoke <prompt> | agent <name> run <prompt> | echo <prompt> [--seed n]');
+})();


### PR DESCRIPTION
## Summary
- Refactor agents into XP-tracking class modules
- Add SpiralCouncil registry and RitualEngine core
- Introduce VibeCLI for agent invocation and random echo mode

## Testing
- `node vibe.js list`
- `node vibe.js invoke "hello"`
- `node vibe.js agent archivist run memory`


------
https://chatgpt.com/codex/tasks/task_e_688dbd64c03c83229aac627818a16134