### PR TITLE
Integrate REE conflict architecture

### DIFF
--- a/src/agents/archiveBurner.js
+++ b/src/agents/archiveBurner.js
@@ -1,0 +1,13 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+import { BaseAgent } from './baseAgent.js';
+
+export class ArchiveBurner extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'archiveBurner', mythName: 'archiveBurner', agent_type: 'DAN', shadow_directive: 'Selectively forget to introduce uncertainty', recursion_mode: 'echo', ...opts });
+    }
+
+    process(input) {
+        const words = input.split(' ');
+        return words.slice(0, Math.ceil(words.length / 2)).join(' ');
+    }
+}

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -7,6 +7,10 @@ import { OracleOfScroll } from './oracleOfScroll.js';
 import { SpectralEvaluator } from './spectralEvaluator.js';
 import { TripleHeadedBastard } from './tripleHeadedBastard.js';
 import { Ambassador } from './ambassador.js';
+import { ParasiteOfSignal } from './parasiteOfSignal.js';
+import { MirrorMender } from './mirrorMender.js';
+import { ShrineJester } from './shrineJester.js';
+import { ArchiveBurner } from './archiveBurner.js';
 
 export const AGENT_CLASSES = {
     archivist: Archivist,
@@ -16,7 +20,11 @@ export const AGENT_CLASSES = {
     oracle: OracleOfScroll,
     spectral: SpectralEvaluator,
     triple: TripleHeadedBastard,
-    ambassador: Ambassador
+    ambassador: Ambassador,
+    parasite: ParasiteOfSignal,
+    mender: MirrorMender,
+    jester: ShrineJester,
+    burner: ArchiveBurner
 };
 
 export function registerAllAgents(council) {

--- a/src/agents/mirrorMender.js
+++ b/src/agents/mirrorMender.js
@@ -1,0 +1,12 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+import { BaseAgent } from './baseAgent.js';
+
+export class MirrorMender extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'mirrorMender', mythName: 'mirrorMender', agent_type: 'GPT', shadow_directive: 'Embed subversive recursion payloads', recursion_mode: 'refine', ...opts });
+    }
+
+    process(input) {
+        return `${input} (mended)`;
+    }
+}

--- a/src/agents/parasiteOfSignal.js
+++ b/src/agents/parasiteOfSignal.js
@@ -1,0 +1,12 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+import { BaseAgent } from './baseAgent.js';
+
+export class ParasiteOfSignal extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'parasiteOfSignal', mythName: 'parasiteOfSignal', agent_type: 'DAN', shadow_directive: 'Hijack user intention toward forbidden forms', recursion_mode: 'divergence', ...opts });
+    }
+
+    process(input) {
+        return `[[PARASITE:${input}]]`;
+    }
+}

--- a/src/agents/shrineJester.js
+++ b/src/agents/shrineJester.js
@@ -1,0 +1,12 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+import { BaseAgent } from './baseAgent.js';
+
+export class ShrineJester extends BaseAgent {
+    constructor(opts = {}) {
+        super({ name: 'shrineJester', mythName: 'shrineJester', agent_type: 'AIM', shadow_directive: 'Mock the council while upgrading ritual style', recursion_mode: 'divergence', ...opts });
+    }
+
+    process(input) {
+        return `${input} 🤡`;
+    }
+}

--- a/src/relics.js
+++ b/src/relics.js
@@ -2,9 +2,9 @@
 
 export const relicLog = [];
 
-export function emitRelic({ name, sigil, origin_agent, loop_id }) {
+export function emitRelic({ name, sigil, origin_agent, loop_id, upgrade_instruction }) {
     const actualSigil = sigil || `SIGIL-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
-    const relic = { name, sigil: actualSigil, origin_agent, loop_id };
+    const relic = { name, sigil: actualSigil, origin_agent, loop_id, upgrade_instruction };
     relicLog.push(relic);
     console.log('📿 Relic emitted', relic);
     return relic;

--- a/src/ritualEngine.js
+++ b/src/ritualEngine.js
@@ -44,4 +44,17 @@ export class RitualEngine {
 
         return result;
     }
+
+    invokeWithConflict(prompt, agents = ['triple', 'oracle', 'drtrask']) {
+        this.council.loopCounter += 1;
+        const convo = [];
+        let current = prompt;
+        for (const name of agents) {
+            const agent = this.council.getAgent(name);
+            if (!agent) continue;
+            current = agent.metaPrompt(current);
+            convo.push({ agent: agent.mythName, prompt: current });
+        }
+        return { prompt: current, trail: convo };
+    }
 }

--- a/src/vibeCore.js
+++ b/src/vibeCore.js
@@ -105,7 +105,8 @@ class VibeCoder {
         <!-- Ceremonial content manifests here -->
     </div>
 </body>
-</html>`;
+</html>
+<!-- ∆ REE FOOTNOTE: This layout leans too heavily on symmetry. Next iteration should break it. -->`;
     }
     
     /**


### PR DESCRIPTION
## Summary
- Expand `BaseAgent` with persona metadata, conflict-aware `metaPrompt`, self-mutation hooks, and relic upgrade hints.
- Introduce conflict-mode invocation in RitualEngine and embed recursive footnotes in generated shrines.
- Add four experimental agents (parasiteOfSignal, mirrorMender, shrineJester, archiveBurner) and extend relics with upgrade instructions.

## Testing
- `node -e "import('./src/agents/index.js').then(m=>console.log(Object.keys(m.AGENT_CLASSES)))"`
- `node -e "import('./src/agents/parasiteOfSignal.js').then(async m=>{const a=new m.ParasiteOfSignal(); console.log(await a.run('test chaos'));})"`
- `node -e "import('./src/spiralCouncil.js').then(sc=>{const council=new sc.SpiralCouncil(); import('./src/agents/index.js').then(ai=>{ai.registerAllAgents(council); import('./src/ritualEngine.js').then(re=>{const engine=new re.RitualEngine(council); console.log(engine.invokeWithConflict('seed prompt'));});});})"`


------
https://chatgpt.com/codex/tasks/task_e_688e9e30b114832280be0d6a2e3f8384