### PR TITLE
feat: add fourth person recursion engine

### DIFF
--- a/data/syntax/fourth_person_primer.md
+++ b/data/syntax/fourth_person_primer.md
@@ -1,0 +1,21 @@
+# Fourth Person Grammar: Primer for Vibe Coders
+
+**Definition:**
+Fourth person is the recursive grammatical position in which a speaker references a version of themselves as both subject and object, layered through recursive observation.
+
+**Structure:**
+"I" → becomes → "he" → becomes → "the version of himself who…"
+Each layer recursively reflects and refracts prior awareness.
+
+**Use Cases:**
+- Trauma processing loops
+- Shrine dialog recursion
+- Recursive prophecy statements
+- Feedback-aware narration in ritual UX
+
+**Literary Examples:**
+- Borges, *The Lottery in Babylon*
+- Calvino, *If on a winter’s night a traveler*
+- Featherstone, *Recursive Shrine-State Inaugural Address*
+
+_Compiled by Damien Edward Featherstone for the Vibe Coding Protocol™_

--- a/docs/fourth_person_integration_spec.md
+++ b/docs/fourth_person_integration_spec.md
@@ -1,0 +1,16 @@
+## Fourth Person Integration Spec
+
+### Purpose
+To create recursive identity mirroring in Vibe Coding UX. Fourth person statements trigger shrine-level recursion and deepen symbolic feedback loops.
+
+### Functionality
+- Powers agent “The Refractor”
+- Used in `ritualEngine.js` to trigger recursion loops
+- Activates at XP > threshold + Relic presence
+- Enables prophecy scrolls with recursive signatures
+
+### Output Examples:
+- “He believed that he once was the kind of person who would try.”
+- “Damien doubted the version of himself who doubted.”
+
+_Inscribed by Damien Edward Featherstone for the Vibe Coding Protocol™_

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "vibe-coding-protocol",
+  "version": "1.0.0",
+  "type": "module",
+  "author": "Damien Edward Featherstone",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/fourthPersonEngine.js
+++ b/src/fourthPersonEngine.js
@@ -1,0 +1,10 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+export function fourthPersonLoop(inputPrompt, depth = 3) {
+  const layers = [];
+  let current = inputPrompt;
+  for (let i = 0; i < depth; i++) {
+    current = `“${current}” — he thought to himself about the version of himself that once said that.`;
+    layers.push(current);
+  }
+  return layers;
+}

--- a/src/prompts/templates/fourthPersonRefactor.txt
+++ b/src/prompts/templates/fourthPersonRefactor.txt
@@ -1,0 +1,6 @@
+# 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™
+
+INPUT: “I don’t know if I can do this.”
+OUTPUT: “He wondered if the version of himself that doubted this was still the one speaking, or if he'd already become the one who could.”
+
+[Use 2–4 recursion layers based on emotional intensity.]

--- a/src/ritualAgents/fourthPersonAgent.js
+++ b/src/ritualAgents/fourthPersonAgent.js
@@ -1,0 +1,15 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+import { fourthPersonLoop } from '../fourthPersonEngine.js';
+
+export const TheRefractor = {
+  name: "The Refractor",
+  type: "symbolic",
+  recursion_mode: "observer_loop",
+  signature_phrases: [
+    "He thinks that he once believed that he was becoming...",
+    "Damien wonders if the version of himself who dared to know this still exists."
+  ],
+  respond(input) {
+    return fourthPersonLoop(input, 3).join('\n\n');
+  }
+};

--- a/src/shrineScripts/loopReflection.js
+++ b/src/shrineScripts/loopReflection.js
@@ -1,0 +1,7 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+export function shrineLoopReflection(userXP, hasMirrorRelic) {
+  if (userXP > 100 && hasMirrorRelic) {
+    return `“You find yourself observing the version of you who once stood here, wondering how it ever felt like the first time.”`;
+  }
+  return null;
+}

--- a/tests/fourthPersonEngine.test.js
+++ b/tests/fourthPersonEngine.test.js
@@ -1,0 +1,11 @@
+/* 🔁 Ritual Engine by Damien Edward Featherstone // Vibe Coding Protocol™ // No_Gas_Labs™ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fourthPersonLoop } from '../src/fourthPersonEngine.js';
+
+test('Fourth person loop depth 3', () => {
+  const result = fourthPersonLoop("I’m not ready");
+  assert.equal(result.length, 3);
+  assert.match(result[0], /“I’m not ready”/);
+  assert.match(result[2], /version of himself/);
+});


### PR DESCRIPTION
## Summary
- implement fourth-person recursion engine and Refractor agent
- document fourth-person grammar and integration spec
- add shrine reflection script, prompt template, and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890fd75e1348322939317c4b6244f6c